### PR TITLE
Add shortcuts for languages and fix mistake

### DIFF
--- a/src/antlr-core/index.js
+++ b/src/antlr-core/index.js
@@ -49,10 +49,15 @@ function compile(config) {
     config.outputDirectory = path.resolve(config.outputDirectory);
 
     switch (config.language) {
+        case 'js':
+        case 'javascript':
         case 'JavaScript':
-            return compileGrammarAsJavaScript(config);
-        case 'TypeScript':
             config.language = 'JavaScript';
+            return compileGrammarAsJavaScript(config);
+        case 'ts':
+        case 'typescript':
+        case 'TypeScript':
+            config.language = 'TypeScript';
             return compileGrammarAsTypeScript(config);
 
         default:


### PR DESCRIPTION
Hello,

As said in my issue #1 in "JavaScript language" part.
I think we can add some shortcuts to simplify the usage of the package.

Also, is `config.language = 'JavaScript';` was a mistake ? If it didn't, I can create another commit to let it as before.