### PR TITLE
Add labeled alternatives into module.exports and declaration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .git
 src/test
 .idea
+.vscode
 node_modules
 antlr4-parser-tool.iml
 lib

--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -35,6 +35,12 @@ export function contextRules(parser: any) {
     });
 }
 
+export function classContextRules(parserClass: any) {
+    return Object.keys(parserClass)
+        .map((key: any) => parserClass[key])
+        .filter(value => typeof value === 'function');
+}
+
 export function contextToRuleMap(parser: any) {
     const map = new Map();
     _.each(parser.ruleNames, (rule) => {
@@ -96,11 +102,13 @@ export function parserMethods(parser: any) {
  * @returns {string[]}
  */
 export function exportedContextTypes(parser: any) {
-    const ParserClass = parser.constructor.name;
-    const ctxNames = contextRuleNames(parser);
+    const ParserClass = parser.constructor;
+    const classCtxNames = classContextRules(ParserClass).map(rule => rule.name);
+    const instanceCtxNames = contextRuleNames(parser);
+    const ctxNames = _.union(instanceCtxNames, classCtxNames);
 
     const exportsStatements = _.map(ctxNames, (ctxType) => {
-        return `exports.${ctxType} = ${ctxType};\n${ParserClass}.${ctxType} = ${ctxType};\n`;
+        return `exports.${ctxType} = ${ctxType};\n${ParserClass.name}.${ctxType} = ${ctxType};\n`;
     });
 
     return exportsStatements;
@@ -112,7 +120,7 @@ export function exportedContextTypes(parser: any) {
  * @returns [...,{id: string, type: string}]
  */
 export function contextObjectAst(parser: any) {
-    const types = contextRules(parser);
+    const types = classContextRules(parser.constructor);
     const ruleToContextMap = ruleToContextTypeMap(parser);
     const symbols = symbolSet(parser);
     const rules = contextRuleNames(parser);


### PR DESCRIPTION
### Problem ###

The other day I've came across the issue that I can't access my labeled alternative rule contexts. It won't declare neither in .d.ts file nor `exports` section in Parser.js file. For example, if I have the grammar with rules like:

```
parse
  : expression EOF
  ;

expression
  : literal                                                    #primaryExpr
  | '(' expression ')'                                         #parensExpr
  | expression op=('*'|'/') expression                         #mulDivExpr
  | expression op=('+'|'-') expression                         #addSubExpr
  | expression op=('AND'|'OR'|'NOT') expression                #booleanExpr
  | expression op=('=='|'!='|'>'|'<'|'>='|'<=') expression     #comparisonExpr
  ;

literal
  : sign=('+'|'-')? NUMBER_LITERAL
  | BOOL_LITERAL
  ;
```

it compiles only `ExpressionContext` and `LiteralContext` classes although Parser.js has members for labeled alternatives.

```ts
  // MyLanguageParser.d.ts


  export declare class ParseContext extends ParserRuleContext {
      // ...
  }

  export declare class ExpressionContext extends ParserRuleContext {
      // ...
  }

  export declare class LiteralContext extends ParserRuleContext {
      // ...
  }
```

```js
  // MyLanguageParser.js


  /* ...generated parser... */

  exports.MyLanguageParser = MyLanguageParser;
  exports.ParseContext = ParseContext;
  MyLanguageParser.ParseContext = ParseContext;
  exports.ExpressionContext = ExpressionContext;
  MyLanguageParser.ExpressionContext = ExpressionContext;
  exports.LiteralContext = LiteralContext;
  MyLanguageParser.LiteralContext = LiteralContext;
```

### Solution ###

I found out this happens because labeled alternative contexts don't exist inside the parser instance. But we can get it from the Parser class itself as static methods. So, if we pass through Parser class keys, we'll get both labeled alternatives and regular rule contexts. Thereby after some corrections I get the following output.

```ts
  // MyLanguageParser.d.ts


  export declare class ParseContext extends ParserRuleContext {
      // ...
  }

  export declare class AddSubExprContext extends ParserRuleContext {
      // ...
  }

  export declare class PrimaryExprContext extends ParserRuleContext {
      // ...
  }

  export declare class BooleanExprContext extends ParserRuleContext {
      // ...
  }

  export declare class ComparisonExprContext extends ParserRuleContext {
      // ...
  }

  export declare class ParensExprContext extends ParserRuleContext {
      // ...
  }

  export declare class MulDivExprContext extends ParserRuleContext {
      // ...
  }

  export declare class LiteralContext extends ParserRuleContext {
      // ...
  }

  export declare class ExpressionContext extends ParserRuleContext {
      // ...
  }

```

```js
  // MyLanguageParser.js


  /* ...generated parser... */

  exports.MyLanguageParser = MyLanguageParser;
  exports.ParseContext = ParseContext;
  MyLanguageParser.ParseContext = ParseContext;
  exports.ExpressionContext = ExpressionContext;
  MyLanguageParser.ExpressionContext = ExpressionContext;
  exports.LiteralContext = LiteralContext;
  MyLanguageParser.LiteralContext = LiteralContext;
  exports.AddSubExprContext = AddSubExprContext;
  MyLanguageParser.AddSubExprContext = AddSubExprContext;
  exports.PrimaryExprContext = PrimaryExprContext;
  MyLanguageParser.PrimaryExprContext = PrimaryExprContext;
  exports.BooleanExprContext = BooleanExprContext;
  MyLanguageParser.BooleanExprContext = BooleanExprContext;
  exports.ComparisonExprContext = ComparisonExprContext;
  MyLanguageParser.ComparisonExprContext = ComparisonExprContext;
  exports.ParensExprContext = ParensExprContext;
  MyLanguageParser.ParensExprContext = ParensExprContext;
  exports.MulDivExprContext = MulDivExprContext;
  MyLanguageParser.MulDivExprContext = MulDivExprContext;
```

After this change I'm able to check the current context instance and safely invoke its inner methods

```ts
  // Example Expression Visitor method


  static visitExpression(ctx: ExpressionContext) {
    if (ctx instanceof PrimaryExprContext) {
      return ExpressionVisitor.visitPrimary(ctx.primary());
    }

    if (ctx instanceof ParensExprContext) {
      return ExpressionVisitor.visitParenthesesExpression(ctx.expression());
    }

    if (
      ctx instanceof AddSubExprContext
      || ctx instanceof MulDivExprContext
      || ctx instanceof BooleanExprContext
      || ctx instanceof ComparisonExprContext
    ) {
      return ExpressionVisitor.visitTwoMembersExpression(ctx);
    }

    throw new Error('Error while visiting ExpressionContext. No expected statements found');
  }
```