### PR TITLE
Resolve missing scope when compiling grammar outside of src folder

### DIFF
--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -5,10 +5,16 @@ import * as util from './util';
 import * as vm from 'vm';
 
 export function readLexer(grammar: string, lexerFile: string) {
-    const contents = fs.readFileSync(lexerFile).toString();
-    const context = { require, exports: {} };
+    const code = fs.readFileSync(lexerFile).toString();
+    const vmRequire = (request: string) => {
+      if (request === 'antlr4/index' || request === 'antlr4') {
+        return require(request);
+      }
+      return require.resolve(request, { paths: [path.dirname(lexerFile)] });
+    };
+    const context = { require: vmRequire, exports: {} as any, __dirname: path.dirname(lexerFile), __filename: path.resolve(lexerFile) };
     vm.createContext(context);
-    vm.runInContext(contents, context);
+    vm.runInContext(code, context);
     const Lexer = context.exports[`${grammar}Lexer`];
     const lexer = new Lexer(null);
 
@@ -16,10 +22,16 @@ export function readLexer(grammar: string, lexerFile: string) {
 }
 
 export function readParser(grammar: string, parserFile: string) {
-    const contents = fs.readFileSync(parserFile).toString();
-    const context = { require, exports: {} };
+    const code = fs.readFileSync(parserFile).toString();
+    const vmRequire = (request: string) => {
+      if (request === 'antlr4/index' || request === 'antlr4') {
+        return require(request);
+      }
+      return require.resolve(request, { paths: [path.dirname(parserFile)] });
+    };
+    const context = { require: vmRequire, exports: {} as any, __dirname: path.dirname(parserFile), __filename: path.resolve(parserFile) };
     vm.createContext(context);
-    vm.runInContext(contents, context);
+    vm.runInContext(code, context);
     const Parser = context.exports[`${grammar}Parser`];
     const parser = new Parser(null);
 

--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -7,10 +7,10 @@ import * as vm from 'vm';
 export function readLexer(grammar: string, lexerFile: string) {
     const code = fs.readFileSync(lexerFile).toString();
     const vmRequire = (request: string) => {
-      if (request === 'antlr4/index' || request === 'antlr4') {
-        return require(request);
-      }
-      return require.resolve(request, { paths: [path.dirname(lexerFile)] });
+        if (request === 'antlr4/index' || request === 'antlr4') {
+            return require(request);
+        }
+        return require.resolve(request, { paths: [path.dirname(lexerFile)] });
     };
     const context = { require: vmRequire, exports: {} as any, __dirname: path.dirname(lexerFile), __filename: path.resolve(lexerFile) };
     vm.createContext(context);
@@ -24,10 +24,10 @@ export function readLexer(grammar: string, lexerFile: string) {
 export function readParser(grammar: string, parserFile: string) {
     const code = fs.readFileSync(parserFile).toString();
     const vmRequire = (request: string) => {
-      if (request === 'antlr4/index' || request === 'antlr4') {
-        return require(request);
-      }
-      return require.resolve(request, { paths: [path.dirname(parserFile)] });
+        if (request === 'antlr4/index' || request === 'antlr4') {
+            return require(request);
+        }
+        return require.resolve(request, { paths: [path.dirname(parserFile)] });
     };
     const context = { require: vmRequire, exports: {} as any, __dirname: path.dirname(parserFile), __filename: path.resolve(parserFile) };
     vm.createContext(context);

--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -2,22 +2,25 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as _ from 'lodash';
 import * as util from './util';
-
-const _eval = require('node-eval');
+import * as vm from 'vm';
 
 export function readLexer(grammar: string, lexerFile: string) {
-    const outputDir = path.dirname(lexerFile);
     const contents = fs.readFileSync(lexerFile).toString();
-    const Lexer = _eval(contents, `${outputDir}/eval.js`)[`${grammar}Lexer`];
+    const context = { require, exports: {} };
+    vm.createContext(context);
+    vm.runInContext(contents, context);
+    const Lexer = context.exports[`${grammar}Lexer`];
     const lexer = new Lexer(null);
 
     return lexer;
 }
 
 export function readParser(grammar: string, parserFile: string) {
-    const outputDir = path.dirname(parserFile);
     const contents = fs.readFileSync(parserFile).toString();
-    const Parser = _eval(contents, `${outputDir}/eval.js`)[`${grammar}Parser`];
+    const context = { require, exports: {} };
+    vm.createContext(context);
+    vm.runInContext(contents, context);
+    const Parser = context.exports[`${grammar}Parser`];
     const parser = new Parser(null);
 
     return parser;


### PR DESCRIPTION
Create context and use vm.runInContext instead of eval to prevent require() module not found exception