### PR TITLE
Add interface for configuration and result

### DIFF
--- a/src/antlr-core/index.ts
+++ b/src/antlr-core/index.ts
@@ -3,8 +3,20 @@ import * as _ from 'lodash';
 import {AntlrCompiler} from './antlr-compiler';
 import * as constants from './constants';
 
+export interface AntlrCompilerConfig {
+    language: 'JavaScript' | 'TypeScript',
+    grammarFiles: string[],
+    outputDirectory: string,
+    antlrJar?: string,
+    listener?: boolean,
+    visitor?: boolean
+}
+  
+export interface AntlrCompilerResult {
+    [grammar: string]: string[]
+}
 
-function compileWithFunction(config: any, compileFunction: (compiler: AntlrCompiler) => { grammar: string, filesGenerated: string[] }) {
+function compileWithFunction(config: AntlrCompilerConfig, compileFunction: (compiler: AntlrCompiler) => { grammar: string, filesGenerated: string[] }): AntlrCompilerResult {
     const compiledResults = {} as any;
 
     _.each(config.grammarFiles, (grammar) => {
@@ -36,11 +48,11 @@ function compileWithFunction(config: any, compileFunction: (compiler: AntlrCompi
     return compiledResults;
 }
 
-function compileGrammarAsJavaScript(config: any) {
+function compileGrammarAsJavaScript(config: AntlrCompilerConfig): AntlrCompilerResult {
     return compileWithFunction(config, (compiler) => compiler.compileJavaScript());
 }
 
-function compileGrammarAsTypeScript(config: any) {
+function compileGrammarAsTypeScript(config: AntlrCompilerConfig): AntlrCompilerResult {
     config = _.clone(config);
 
     // Define the language as JavaScript for the Antlr4 Jar
@@ -48,7 +60,7 @@ function compileGrammarAsTypeScript(config: any) {
     return compileWithFunction(config, (compiler) => compiler.compileTypeScript());
 }
 
-export function compile(config: any) {
+export function compile(config: AntlrCompilerConfig): AntlrCompilerResult {
     config.outputDirectory = path.resolve(config.outputDirectory);
 
     switch (config.language) {

--- a/src/antlr-core/index.ts
+++ b/src/antlr-core/index.ts
@@ -4,23 +4,23 @@ import {AntlrCompiler} from './antlr-compiler';
 import * as constants from './constants';
 
 export interface AntlrCompilerConfig {
-    language: 'JavaScript' | 'TypeScript',
-    grammarFiles: string[],
-    outputDirectory: string,
-    antlrJar?: string,
-    listener?: boolean,
-    visitor?: boolean
+    language: 'js' | 'javascript' | 'JavaScript' | 'ts' | 'typescript' | 'TypeScript';
+    grammarFiles: string[];
+    outputDirectory: string;
+    antlrJar?: string;
+    listener?: boolean;
+    visitor?: boolean;
 }
-  
+
 export interface AntlrCompilerResult {
-    [grammar: string]: string[]
+    [grammar: string]: string[];
 }
 
 function compileWithFunction(config: AntlrCompilerConfig, compileFunction: (compiler: AntlrCompiler) => { grammar: string, filesGenerated: string[] }): AntlrCompilerResult {
     const compiledResults = {} as any;
 
     _.each(config.grammarFiles, (grammar) => {
-        const opts = _.clone(config);
+        const opts = _.clone(config) as any;
         opts.grammarFile = path.resolve(grammar);
         opts.outputDirectory = path.resolve(config.outputDirectory);
 


### PR DESCRIPTION
Add `AntlrCompilerConfig` and `AntlrCompilerResult` interfaces to enhance TypeScript support for using antlr4-tool as a lib.

```typescript
export interface AntlrCompilerConfig {
    language: 'JavaScript' | 'TypeScript',
    grammarFiles: string[],
    outputDirectory: string,
    antlrJar?: string,
    listener?: boolean,
    visitor?: boolean
}
```

```typescript
export interface AntlrCompilerResult {
    [grammar: string]: string[]
}
```