### PR TITLE
Added typings for Visitor and context fields.

### DIFF
--- a/src/antlr-core/antlr-compiler.ts
+++ b/src/antlr-core/antlr-compiler.ts
@@ -66,6 +66,19 @@ export class AntlrCompiler {
         return dest;
     }
 
+    compileTypeScriptVisitor(grammar: string, parser: any) {
+        const className = `${grammar}Visitor`;
+        const dest = `${this.outputDirectory}/${className}.d.ts`;
+        const template = fs.readFileSync(`${__dirname}/templates/visitor.d.ts.ejs`).toString();
+        const map = parserUtil.ruleToContextTypeMap(parser);
+
+        const contents = ejs.render(template, {_: _, className: className});
+
+        fs.writeFileSync(dest, contents);
+
+        return dest;
+    }
+
     compileTypeScriptLexer(grammar: string) {
         const className = `${grammar}Lexer`;
         const dest = `${this.outputDirectory}/${className}.d.ts`;
@@ -81,7 +94,6 @@ export class AntlrCompiler {
         const jsCompliedResults = this.compileJavaScript();
         const grammar = jsCompliedResults.grammar;
         const parserFile = `${this.outputDirectory}/${grammar}Parser.js`;
-
 
         if (fs.existsSync(parserFile)) {
             let parser = parserUtil.readParser(grammar, parserFile);
@@ -104,6 +116,16 @@ export class AntlrCompiler {
                 } else if (fs.existsSync(`${this.outputDirectory}/${grammar}ParserListener.js`)) {
                     const listenerFile = this.compileTypeScriptListener(`${grammar}Parser`, parser);
                     jsCompliedResults.filesGenerated.push(listenerFile);
+                }
+            }
+
+            if (this.config.visitor) {
+                if (fs.existsSync(`${this.outputDirectory}/${grammar}Visitor.js`)) {
+                    const visitorFile = this.compileTypeScriptVisitor(grammar, parser);
+                    jsCompliedResults.filesGenerated.push(visitorFile);
+                } else if (fs.existsSync(`${this.outputDirectory}/${grammar}ParserVisitor.js`)) {
+                    const visitorFile = this.compileTypeScriptVisitor(`${grammar}Parser`, parser);
+                    jsCompliedResults.filesGenerated.push(visitorFile);
                 }
             }
 

--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -139,15 +139,24 @@ export function contextObjectAst(parser: any) {
     const ruleToContextMap = ruleToContextTypeMap(parser);
     const symbols = symbolSet(parser);
     const rules = contextRuleNames(parser);
+    const fieldFilter = new Set(['children', 'start', 'stop', 'exception']);
 
     return _.map(types, (context) => {
         const obj = {} as any;
         obj.name = context.name;
 
+        const inst = new context(parser.parser, {});
+
+        const fields = util.getFields(inst);
+        const contextFields = _.filter(fields, field => !fieldFilter.has(field));
+
+        obj.fields = _.map(contextFields, (field) => ({
+            name: field,
+            type: ruleToContextMap.get(field) || 'ParserRuleContext'
+        }));
+
         const methods = _.filter(util.getMethods(context.prototype), (mth) => mth !== 'depth');
-        const ownMethods = _.filter(methods, method => (
-            ruleToContextMap.has(method.name) || symbols.has(method.name)
-        ));
+        const ownMethods = _.filter(methods, method => ruleToContextMap.has(method.name) || symbols.has(method.name));
 
         obj.methods = _.map(ownMethods, (method) => {
             const methodObj = {} as any;

--- a/src/antlr-core/templates/parser.d.ts.ejs
+++ b/src/antlr-core/templates/parser.d.ts.ejs
@@ -3,6 +3,10 @@ import {TerminalNode} from 'antlr4/tree/Tree';
 
 <% _.each(contextRules, (contextRule) => { %>
 export declare class <%= contextRule.name %> extends ParserRuleContext {
+    <% _.each(contextRule.fields, (field) => { %>
+    <%= field.name %>: <%= field.type %>;
+    <% }); %>
+
     <% _.each(contextRule.methods, (method) => { %>
     <%= method.name %>(): <%= method.type %>;
     <% }); %>

--- a/src/antlr-core/templates/visitor.d.ts.ejs
+++ b/src/antlr-core/templates/visitor.d.ts.ejs
@@ -1,0 +1,5 @@
+import {CommonTokenStream, ParserRuleContext, Token} from 'antlr4';
+import {ParseTreeVisitor} from 'antlr4/tree/Tree';
+
+export declare class <%= className %> extends ParseTreeVisitor {
+}

--- a/src/antlr-core/util.ts
+++ b/src/antlr-core/util.ts
@@ -1,9 +1,22 @@
 import * as path from 'path';
 
+export function getFields(obj: any): any[] {
+    const result: any[] = [];
+    for (const id of Object.keys(obj)) {
+        try {
+            if (obj[id] === null) {
+                result.push(id);
+            }
+        } catch (err) {
+        }
+    }
+
+    return result;
+}
+
 export function getMethods(obj: any): any[] {
     const result: any[] = [];
-    /* tslint:disable */
-    for (const id in obj) {
+    for (const id of Object.keys(obj)) {
         try {
             if (typeof(obj[id]) === 'function' && obj[id].length === 0) {
                 const mth = {name: id, args: ''};


### PR DESCRIPTION
I added generation of a *Visitor.d.ts file: without this it is difficult to inherit from the visitor, as typescript cannot figure out that it inherits from `ParseTreeVisitor`.

I also added support for fields on the `ParserRuleContext`s, but currently their type just default's to `ParserRuleContext` since there does not appear to be a way to get their types without changing the way that the javascript is generated, or by parsing them out of the comments.  