### PR TITLE
Added support for fields on Context objects.

### DIFF
--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -139,10 +139,21 @@ export function contextObjectAst(parser: any) {
     const ruleToContextMap = ruleToContextTypeMap(parser);
     const symbols = symbolSet(parser);
     const rules = contextRuleNames(parser);
+    const fieldFilter = new Set(['children', 'start', 'stop', 'exception']);
 
     return _.map(types, (context) => {
         const obj = {} as any;
         obj.name = context.name;
+
+        const inst = new context(parser.parser, {});
+
+        const fields = util.getFields(inst);
+        const contextFields = _.filter(fields, field => !fieldFilter.has(field));
+
+        obj.fields = _.map(contextFields, (field) => ({
+            name: field,
+            type: ruleToContextMap.get(field) || 'ParserRuleContext'
+        }));
 
         const methods = _.filter(util.getMethods(context.prototype), (mth) => mth !== 'depth');
         const ownMethods = _.filter(methods, method => (

--- a/src/antlr-core/templates/parser.d.ts.ejs
+++ b/src/antlr-core/templates/parser.d.ts.ejs
@@ -3,6 +3,9 @@ import {TerminalNode} from 'antlr4/tree/Tree';
 
 <% _.each(contextRules, (contextRule) => { %>
 export declare class <%= contextRule.name %> extends ParserRuleContext {
+    <% _.each(contextRule.fields, (field) => { %>
+    <%= field.name %>: <%= field.type %>;
+    <% }); %>
     <% _.each(contextRule.methods, (method) => { %>
     <%= method.name %>(): <%= method.type %>;
     <% }); %>

--- a/src/antlr-core/util.ts
+++ b/src/antlr-core/util.ts
@@ -1,5 +1,19 @@
 import * as path from 'path';
 
+export function getFields(obj: any): any[] {
+    const result: any[] = [];
+    for (const id of Object.keys(obj)) {
+        try {
+            if (obj[id] === null) {
+                result.push(id);
+            }
+        } catch (err) {
+        }
+    }
+
+    return result;
+}
+
 export function getMethods(obj: any): any[] {
     const result: any[] = [];
     /* tslint:disable */


### PR DESCRIPTION
Adds fields to context objects, although they all have the type `ParserRuleContext`.  To give better types would require a change to the javascript generator or to parse the generated javascript code and extract the type from the comments (as far as I know).