### PR TITLE
Added windows platform support to the antlr compiler

### DIFF
--- a/src/antlr-core/antlr-compiler.ts
+++ b/src/antlr-core/antlr-compiler.ts
@@ -122,7 +122,11 @@ export class AntlrCompiler {
         let grammar;
 
         chdir(dir, () => {
-            child.execSync('which java');
+            if (process.platform === 'win32') {
+                child.execSync('where java');
+            } else {
+                child.execSync('which java');
+            }
 
             const cmd = this.command();
             try {


### PR DESCRIPTION
Added a simple check inside of the antlr-compiler.ts file that checks to
see if the node process is running on the windows platform where it will
run the windows equivalent command.