### PR TITLE
Lexer- and parser-relative require resolution

### DIFF
--- a/src/antlr-core/parser-util.ts
+++ b/src/antlr-core/parser-util.ts
@@ -7,10 +7,7 @@ import * as vm from 'vm';
 export function readLexer(grammar: string, lexerFile: string) {
     const code = fs.readFileSync(lexerFile).toString();
     const vmRequire = (request: string) => {
-        if (request === 'antlr4/index' || request === 'antlr4') {
-            return require(request);
-        }
-        return require.resolve(request, { paths: [path.dirname(lexerFile)] });
+        return require(require.resolve(request, { paths: [path.dirname(lexerFile)] }));
     };
     const context = { require: vmRequire, exports: {} as any, __dirname: path.dirname(lexerFile), __filename: path.resolve(lexerFile) };
     vm.createContext(context);
@@ -24,11 +21,7 @@ export function readLexer(grammar: string, lexerFile: string) {
 export function readParser(grammar: string, parserFile: string) {
     const code = fs.readFileSync(parserFile).toString();
     const vmRequire = (request: string) => {
-        if (request === 'antlr4/index' || request === 'antlr4') {
-            return require(request);
-        }
-
-        return require(parserFile);
+        return require(require.resolve(request, { paths: [path.dirname(parserFile)] }));
     };
     const context = { require: vmRequire, exports: {} as any, __dirname: path.dirname(parserFile), __filename: path.resolve(parserFile) };
     const newCtx = vm.createContext(context);


### PR DESCRIPTION
This PR fixes the vmRequire functions for reading the lexer and parser during Typescript declaration generation. The git history indicates that problems in this area are due to slight misuse of the `require.resolve` function which returns a path string, not a module. Later changes worked around this problem in the case of the parser but limited the require to 'antlr4/index', 'antlr4', or the parserFile itself. Therefore any custom imports in the antlr grammar (for example, any require statement in the `@header` section) could not be loaded, leading to generation problems. 
This PR simplifies require resolution by using `require.resolve` relative to the lexer and parser file to return the module path, and then `require`-ing that path. This should work in a general way, eliminating the need for the various conditions in `vmRequire`.